### PR TITLE
Read the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ and [Kyle M. Douglass](https://github.com/kmdouglass) in the
 [Laboratory of Experimental Biophysics](http://leb.epfl.ch/) for
 modeling DNA.
 
+# Documentation
+
+PolymerCpp documentation may be found at http://polymercpp.readthedocs.io/en/latest/
+
 # License
 
 PolymerCpp is licensed under the GNU General Public License,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,21 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('.'))
 
+from unittest.mock import MagicMock
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+            return MagicMock()
+
+MOCK_MODULES = [
+    'numpy',
+    'matplotlib',
+    'matplotlib.pyplot',
+    'mpl_toolkits.mplot3d'
+]
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
The conf.py file to automatically build the documentation now works with module mocking. This should enable automatic documentation builds for every push to GitHub.

@MStefko , will you please create a [https://readthedocs.org/](Read the Docs) account so I can give you admin access? If you don't mind, would you also please give me admin rights to this GitHub repo? I can't complete the RTD setup without them.